### PR TITLE
Try to get rid of error from action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -72,8 +72,6 @@ runs:
 
       - name: Build components of the spell check comment
         id: build-components
-        env:
-          GH_PAT: ${{ inputs.gh_pat }}
         run: |
           error_url=https://raw.githubusercontent.com/${{inputs.git_path}}/${{ inputs.branch_name }}/${{ steps.chk_results.outputs.report_path }}
           echo ::set-output name=time::$(date +'%Y-%m-%d')


### PR DESCRIPTION
See: https://github.com/jhudsl/ottr-reports-commenting/actions/runs/2053417791

There's this error that's stopping things and I haven't figured out what it means yet. 
```
System.ArgumentException: Unexpected type '' encountered while reading 'action manifest root'. The type 'MappingToken' was expected.    at GitHub.DistributedTask.ObjectTemplating.Tokens.TemplateTokenExtensions.AssertMapping(TemplateToken value, String objectDescription)    at GitHub.Runner.Worker.ActionManifestManager.Load(IExecutionContext executionContext, String manifestFile)
```